### PR TITLE
[FEAT] Allow "per-device" path.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
 		"obsidian": "latest",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"
+	},
+	"dependencies": {
+		"node-machine-id": "^1.1.12"
 	}
 }

--- a/src/settings/SettingsInterface.ts
+++ b/src/settings/SettingsInterface.ts
@@ -1,4 +1,5 @@
 import { join, normalize, sep as slash } from 'path';
+
 const xdg = require('@folder/xdg');
 
 export interface GlobalSettings {
@@ -9,6 +10,8 @@ export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
 	profilesList: []
 }
 
+export type DeviceIds = Record<string, string>
+
 export interface VaultSettings {
 	profilesPath: string;
 	activeProfile: Partial<ProfileOptions>;
@@ -16,6 +19,7 @@ export interface VaultSettings {
 	profileUpdateDelay: number;
 	uiUpdate: boolean;
 	uiUpdateInterval: number;
+	devices?: DeviceIds;
 }
 
 export const DEFAULT_VAULT_SETTINGS: VaultSettings = {
@@ -25,6 +29,7 @@ export const DEFAULT_VAULT_SETTINGS: VaultSettings = {
 	profileUpdateDelay: 800,
 	uiUpdate: true,
 	uiUpdateInterval: 1000,
+	devices: {}
 }
 
 export interface ProfileOptions {


### PR DESCRIPTION
The plugin have some problem using sync, as the path will be exactly the same even on different computer. I added the “node-machine-id” dep to generate an ID for each device. Each device will have always different ID, so the path will be saved in a “per device” and charged by the ID. When the path is updated, it is also saved in the devices' configuration.

## Describe your changes
- Add new dependencies : [`node-machine-id`](https://www.npmjs.com/package/node-machine-id) to get an unique, hardware independent, machine ID based on Machine OS.
- `main.ts` : 
  - `loadDeviceId` : Identify strictly the machine and change the `vaultSettings.profilePath` if exists. Else, create it and save.
  - `saveDeviceId` : When the settings of the path is updated, it also updates and the saves the device.
- `settingsInterface` : Added `type DeviceIds = Record<string, string>` and updated `VaultSettings` with adding it and updated the `DEFAULT_VAULT_SETTINGS` accordingly.

## Related Issues
#37

## Checklist before requesting a review
- [x] I have followed the guidelines in our Contributing document
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My code fixes the feature discussed in #37 

## How has this been tested?
**OS:** Win 11

**Obsidian Version:** 1.8.1

### Tests
- Testing changing ID on vault A 
- Testing load/unload on vault A
- Testing and checking the ID on vault B (ID should be the same)
